### PR TITLE
allow multiple args by using spread operator

### DIFF
--- a/Machine.js
+++ b/Machine.js
@@ -3,10 +3,10 @@ export default function Machine(def, data) {
 
     Object.keys(def).filter(k => k !== '__start__').forEach(stateName => {
         Object.keys(def[stateName]).forEach(eventName => {
-            machine[eventName] = (args) => {
+            machine[eventName] = (...args) => {
                 const {state, handler} = def[machine.state][eventName]
                 machine.state = state
-                return handler ? handler(machine, args) : Promise.resolve()
+                return handler ? handler(machine, ...args) : Promise.resolve()
             }
         })
     })


### PR DESCRIPTION
## Why does this PR exist?
It allows using multiple args by using spread syntax (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)

### How should this be manually tested?
add multiple params to your events.

### How does it look?
the same but with three dots :D

### Is there anything to discuss?
if this PR is desirable. It would also be fine by me to use an array for providing many params to events.
